### PR TITLE
Add almacen blueprint and templates

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,11 +25,13 @@ def create_app():
     from .auth.routes import bp as auth_bp
     from .ganaderia.routes import bp as ganaderia_bp
     from .sanitario.routes import bp as sanitario_bp
+    from .almacen.routes import bp as almacen_bp
     from .main.routes import bp as main_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(ganaderia_bp)
     app.register_blueprint(sanitario_bp)
+    app.register_blueprint(almacen_bp)
     app.register_blueprint(main_bp)
 
     with app.app_context():

--- a/app/almacen/routes.py
+++ b/app/almacen/routes.py
@@ -1,0 +1,15 @@
+from flask import Blueprint, render_template
+
+bp = Blueprint('almacen', __name__, url_prefix='/almacen')
+
+@bp.route('/')
+def almacen_insumos():
+    return render_template('almacen_insumos.html')
+
+@bp.route('/maquinaria')
+def almacen_maquinaria():
+    return render_template('almacen_maquinaria.html')
+
+@bp.route('/agroquimicos')
+def almacen_agroquimicos():
+    return render_template('almacen_agroquimicos.html')

--- a/app/templates/almacen_agroquimicos.html
+++ b/app/templates/almacen_agroquimicos.html
@@ -1,0 +1,83 @@
+{% extends 'base.html' %}
+{% block title %}Agroquimicos{% endblock %}
+{% block content %}
+<div class="container-fluid mt-2">
+    <div class="row">
+        <div class="col-md-4">
+            <div class="card shadow-lg border-4 mb-4">
+                <div class="card-header bg-success text-white text-center">
+                    <h5 class="mb-0">Registro de Agroquimicos</h5>
+                    </div>
+                <div class="card-body bg-light">
+                    <form>
+                        <div class="row">
+                            <div class="col-md-12 mb-3">
+                                <label for="nombreInsumo" class="form-label">Nombre del Insumo</label>
+                                <input type="text" class="form-control" id="nombreInsumo" name="nombreInsumo" required>
+                            </div>
+                            <div class="col-md-3 mb-3">
+                                <label for="Codigo" class="form-label">Codigo</label>
+                                <input type="number" class="form-control" id="Codigo" name="Codigo" required>
+                            </div>
+                            <div class="col-md-3 mb-3">
+                                <label for="cantidad" class="form-label">Cantidad</label>
+                                <input type="number" class="form-control" id="cantidad" name="cantidad" required>
+                            </div>
+                            <div class="col-md-3 mb-3">
+                                <label for="unidad" class="form-label">Unidad</label>
+                                <select class="form-select" id="unidad" name="unidad">
+                                    <option value="Kg">Kg</option>
+                                    <option value="Litros">Litros</option>
+                                    <option value="Unidades">Unidades</option>
+                                </select>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="fechaIngreso" class="form-label">Fecha de Ingreso</label>
+                                <input type="date" class="form-control" id="fechaIngreso" name="fechaIngreso" required>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="fechaVencimiento" class="form-label">Fecha de Vencimiento</label>
+                                <input type="date" class="form-control" id="fechaVencimiento" name="fechaVencimiento" required>
+                            </div>
+                            <div class="col-md-12 mb-3">
+                                <label for="Observaciones" class="form-label">Observaciones</label>
+                                <input type="text" class="form-control" id="Observaciones" name="Observaciones">
+                            </div>
+                        </div>
+                        <div class="card-footer text-end mt-3">
+                            <button type="submit" class="btn btn-success me-2">
+                                <i class="bi bi-save"></i> Guardar
+                            </button>
+                            <button type="reset" class="btn btn-secondary">
+                                <i class="bi bi-x-circle"></i> Cancelar
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Tabla de Datos -->
+        <div class="col-md-8 pe-4">
+            <h5 class="text-success text-center mb-3">Datos de Agroquimicos</h5>
+            <div class="table-responsive">
+              <table class="table table-bordered table-striped">
+                <thead class="table-success text-center">
+                        <tr>
+                            <th>Nombre</th>
+                            <th>Codigo</th>
+                            <th>Cantidad</th>
+                            <th>Unidad</th>
+                            <th>Fecha de Ingreso</th>
+                            <th>Fecha de Ingreso</th>
+                            <th>Observaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/almacen_insumos.html
+++ b/app/templates/almacen_insumos.html
@@ -1,0 +1,84 @@
+{% extends 'base.html' %}
+{% block title %}Almacén{% endblock %}
+{% block content %}
+<div class="container-fluid mt-2">
+    <div class="row">
+        <div class="col-md-4">
+            <div class="card shadow-lg border-4 mb-4">
+                <div class="card-header bg-success text-white text-center">
+                    <h5 class="mb-0">Registro de Insumos</h5>
+                    </div>
+                <div class="card-body bg-light">
+                    <form>
+                        <div class="row">
+                            <div class="col-md-12 mb-3">
+                                <label for="nombreInsumo" class="form-label">Nombre del Insumo</label>
+                                <input type="text" class="form-control" id="nombreInsumo" name="nombreInsumo" required>
+                            </div>
+                            
+                            <div class="col-md-3 mb-3">
+                                <label for="Codigo" class="form-label">Codigo</label>
+                                <input type="number" class="form-control" id="Codigo" name="Codigo" required>
+                            </div>
+                            <div class="col-md-3 mb-3">
+                                <label for="cantidad" class="form-label">Cantidad</label>
+                                <input type="number" class="form-control" id="cantidad" name="cantidad" required>
+                            </div>
+                            <div class="col-md-3 mb-3">
+                                <label for="unidad" class="form-label">Unidad</label>
+                                <select class="form-select" id="unidad" name="unidad">
+                                    <option value="Kg">Kg</option>
+                                    <option value="Litros">Litros</option>
+                                    <option value="Unidades">Unidades</option>
+                                </select>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="fechaIngreso" class="form-label">Fecha de Ingreso</label>
+                                <input type="date" class="form-control" id="fechaIngreso" name="fechaIngreso" required>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="fechaVencimiento" class="form-label">Fecha de Vencimiento</label>
+                                <input type="date" class="form-control" id="fechaVencimiento" name="fechaVencimiento" required>
+                            </div>
+                            <div class="col-md-12 mb-3">
+                                <label for="Observaciones" class="form-label">Observaciones</label>
+                                <input type="text" class="form-control" id="Observaciones" name="Observaciones">
+                            </div>
+                        </div>
+                        <div class="card-footer text-end mt-3">
+                            <button type="submit" class="btn btn-success me-2">
+                                <i class="bi bi-save"></i> Guardar
+                            </button>
+                            <button type="reset" class="btn btn-secondary">
+                                <i class="bi bi-x-circle"></i> Cancelar
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Tabla de Datos -->
+        <div class="col-md-8 pe-4">
+            <h5 class="text-success text-center mb-3">Datos de Insumos</h5>
+            <div class="table-responsive">
+              <table class="table table-bordered table-striped">
+                <thead class="table-success text-center">
+                        <tr>
+                            <th>Nombre</th>
+                            <th>Codigo</th>
+                            <th>Cantidad</th>
+                            <th>Unidad</th>
+                            <th>Fecha de Ingreso</th>
+                            <th>Fecha de Vencimiento</th>
+                            <th>Observaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/almacen_maquinaria.html
+++ b/app/templates/almacen_maquinaria.html
@@ -1,0 +1,79 @@
+{% extends 'base.html' %}
+{% block title %}Maquinaria{% endblock %}
+{% block content %}
+<div class="container-fluid mt-2">
+    <div class="row">
+        <div class="col-md-4">
+            <div class="card shadow-lg border-4 mb-4">
+                <div class="card-header bg-success text-white text-center">
+                    <h5 class="mb-0">Registro de Maquinaria</h5>
+                    </div>
+                <div class="card-body bg-light">
+                    <form>
+                        <div class="row">
+                            <div class="col-md-12 mb-3">
+                                <label for="nombreInsumo" class="form-label">Nombre del Insumo</label>
+                                <input type="text" class="form-control" id="nombreInsumo" name="nombreInsumo" required>
+                            </div>
+                            
+                            <div class="col-md-3 mb-3">
+                                <label for="Codigo" class="form-label">Codigo</label>
+                                <input type="number" class="form-control" id="Codigo" name="Codigo" required>
+                            </div>
+                            <div class="col-md-3 mb-3">
+                                <label for="cantidad" class="form-label">Cantidad</label>
+                                <input type="number" class="form-control" id="cantidad" name="cantidad" required>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="fechaIngreso" class="form-label">Fecha de Ingreso</label>
+                                <input type="date" class="form-control" id="fechaIngreso" name="fechaIngreso" required>
+                            </div>
+                            <div class="col-md-8 mb-3">
+                                <label for="marca" class="form-label">marca</label>
+                                <input type="text" class="form-control" id="marca" name="marca" required>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="serie" class="form-label">serie</label>
+                                <input type="text" class="form-control" id="serie" name="serie" required>
+                            </div>
+                            <div class="col-md-12 mb-3">
+                                <label for="Observaciones" class="form-label">Observaciones</label>
+                                <input type="text" class="form-control" id="Observaciones" name="Observaciones">
+                            </div>
+                        </div>
+                        <div class="card-footer text-end mt-3">
+                            <button type="submit" class="btn btn-success me-2">
+                                <i class="bi bi-save"></i> Guardar
+                            </button>
+                            <button type="reset" class="btn btn-secondary">
+                                <i class="bi bi-x-circle"></i> Cancelar
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Tabla de Datos -->
+        <div class="col-md-8 pe-4">
+            <h5 class="text-success text-center mb-3">Datos de Maquinaria</h5>
+            <div class="table-responsive">
+              <table class="table table-bordered table-striped">
+                <thead class="table-success text-center">
+                        <tr>
+                            <th>Nombre</th>
+                            <th>Codigo</th>
+                            <th>Cantidad</th>
+                            <th>Unidad</th>
+                            <th>Fecha de Ingreso</th>
+                            <th>Marca</th>
+                            <th>Serie</th>
+                            <th>Observaciones</th>
+                        </tr>
+                    </thead>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -52,9 +52,9 @@
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" href="#" id="almacenDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Almacén</a>
                             <ul class="dropdown-menu" aria-labelledby="almacenDropdown">
-                                <li><a class="dropdown-item" href="#">Almacén</a></li>
-                                <li><a class="dropdown-item" href="#">Maquinaria</a></li>
-                                <li><a class="dropdown-item" href="#">Agroquímicos</a></li>
+                                <li><a class="dropdown-item" href="{{ url_for('almacen.almacen_insumos') }}">Almacén</a></li>
+                                <li><a class="dropdown-item" href="{{ url_for('almacen.almacen_maquinaria') }}">Maquinaria</a></li>
+                                <li><a class="dropdown-item" href="{{ url_for('almacen.almacen_agroquimicos') }}">Agroquímicos</a></li>
                             </ul>
                         </li>
                         <li class="nav-item"><a class="nav-link" href="#">Informes</a></li>


### PR DESCRIPTION
## Summary
- add `almacen` blueprint with routes for insumos, maquinaria and agroquimicos
- create Jinja templates for almacen views
- link new pages in navbar
- register new blueprint in app factory

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ❌ `python -m flask --app run.py routes` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_6882d12aa0d08329aba5407a083babd2