### PR TITLE
Implement finca registration endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,6 +14,14 @@ def crear_tablas():
                 contrasena VARCHAR(100) NOT NULL
             )"""
         )
+        cursor.execute(
+            """CREATE TABLE IF NOT EXISTS finca (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                nombre VARCHAR(100) NOT NULL,
+                ubicacion VARCHAR(255),
+                tamano DECIMAL(10,2)
+            )"""
+        )
         mysql.connection.commit()
 
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,4 +1,17 @@
-from flask import Blueprint, render_template, redirect, url_for, flash, session
+from flask import (
+    Blueprint,
+    render_template,
+    redirect,
+    url_for,
+    flash,
+    session,
+    request,
+    jsonify,
+)
+import logging
+import MySQLdb.cursors
+from werkzeug.security import generate_password_hash
+from .. import mysql
 
 main_bp = Blueprint('main', __name__)
 
@@ -15,3 +28,48 @@ def crear_finca():
         flash('Debes iniciar sesión para acceder.', 'warning')
         return redirect(url_for('auth.login'))
     return render_template('crear_finca.html')
+
+
+@main_bp.route('/api/finca', methods=['POST'])
+def api_finca():
+    """Registrar una nueva finca y el primer usuario administrador."""
+    try:
+        data = request.get_json() if request.is_json else request.form
+        nombre = data.get('nombre')
+        ubicacion = data.get('ubicacion')
+        tamano = data.get('tamano')
+        usuario = data.get('usuario')
+        contrasena = data.get('contrasena')
+
+        if not nombre or not usuario or not contrasena:
+            return (
+                jsonify(status='error', message='Datos obligatorios faltantes'),
+                400,
+            )
+
+        with mysql.connection.cursor(MySQLdb.cursors.DictCursor) as cursor:
+            cursor.execute(
+                'INSERT INTO finca (nombre, ubicacion, tamano) VALUES (%s, %s, %s)',
+                (nombre, ubicacion, tamano),
+            )
+            finca_id = cursor.lastrowid
+
+            cursor.execute('SELECT COUNT(*) AS cnt FROM usuarios')
+            if cursor.fetchone()['cnt'] == 0:
+                hashed = generate_password_hash(contrasena)
+                cursor.execute(
+                    'INSERT INTO usuarios (usuario, contrasena) VALUES (%s, %s)',
+                    (usuario, hashed),
+                )
+                session['usuario'] = usuario
+
+            mysql.connection.commit()
+
+        return (
+            jsonify(status='success', message='Registro guardado', redirect='/dashboard'),
+            201,
+        )
+    except Exception as e:
+        logging.exception('Error registrando finca')
+        mysql.connection.rollback()
+        return jsonify(status='error', message=str(e)), 500

--- a/app/templates/crear_finca.html
+++ b/app/templates/crear_finca.html
@@ -18,6 +18,14 @@
                     <label for="tamano" class="form-label">Tamaño (ha)</label>
                     <input type="number" class="form-control" id="tamano" name="tamano" placeholder="Superficie en hectáreas" />
                 </div>
+                <div class="mb-3">
+                    <label for="usuario" class="form-label">Usuario Administrador</label>
+                    <input type="text" class="form-control" id="usuario" name="usuario" placeholder="Nombre de usuario" />
+                </div>
+                <div class="mb-3">
+                    <label for="contrasena" class="form-label">Contraseña</label>
+                    <input type="password" class="form-control" id="contrasena" name="contrasena" placeholder="Contraseña" />
+                </div>
                 <div class="d-flex justify-content-end">
                     <button type="submit" class="btn btn-success">Guardar</button>
                 </div>
@@ -25,4 +33,34 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    document.querySelector('form').addEventListener('submit', async function(e) {
+        e.preventDefault();
+        const data = {
+            nombre: document.getElementById('nombre').value,
+            ubicacion: document.getElementById('ubicacion').value,
+            tamano: document.getElementById('tamano').value,
+            usuario: document.getElementById('usuario').value,
+            contrasena: document.getElementById('contrasena').value,
+        };
+        try {
+            const resp = await fetch('/api/finca', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            const res = await resp.json();
+            if (res.status === 'success') {
+                window.location.href = res.redirect || '/dashboard';
+            } else {
+                alert(res.message || 'Error al registrar');
+            }
+        } catch (err) {
+            alert('Error al conectar con el servidor');
+        }
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- create `finca` table at startup
- build `/api/finca` endpoint for inserting a new farm and first admin user
- extend `crear_finca.html` to submit via JavaScript using fetch

## Testing
- `python3 -m py_compile app/__init__.py app/main/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f5c5cf988329ab355e5fcfee890d